### PR TITLE
Mobile support

### DIFF
--- a/direct.js
+++ b/direct.js
@@ -48,11 +48,21 @@
 
     ready('a', function(element) {
         if (element.getAttribute('target') === "_blank") {
-            element.onmousedown = function() {
-                element.href = element.href.replace(/&?fbclid(=|%3D|%3d)[^&#$/]*/gi, '');
+            let updateElement = function() {
+                let uri = element.href;
+                if (/^https?:\/\/lm?.facebook.com/i.test(uri)) {
+                    uri = uri.match(/u=([^&#$]+)/i)[1];
+                }
+                uri = decodeURIComponent(uri);
+                uri = uri.replace(/&?fbclid=[^&#$/]*/gi, '');
+
+                element.href = uri;
                 element.setAttribute("data-lynx-uri", "");
                 return true;
             };
+
+            element.onmousedown = updateElement;
+            element.ontouchstart = updateElement;
         }
     });
 })(this);


### PR DESCRIPTION
This adds event listener for `touchstart` event and rewrites
the redirection links to original URL.

This probably needs some more testing, as I'm not too familiar
with facebook and all it's edge cases, but the things I tried out,
this upgrade seemed to work well.

Related issue: #4 