### PR TITLE
[#7] Added support for copying URL without tracking via right lick

### DIFF
--- a/direct.js
+++ b/direct.js
@@ -62,6 +62,7 @@
             };
 
             element.onmousedown = updateElement;
+            element.contextmenu = updateElement;
             element.ontouchstart = updateElement;
         }
     });


### PR DESCRIPTION
This adds the enhancement described in issue #7 
Instead of detecting right click mouse events, I decided to use the contextmenu event browsers provide.
This should work on most browsers on desktop (Firefox doesn't support this for disabled items which isn't an issue in this case) but mobile support is iffy which also shouldn't matter too much in this case but let me know if you would like me to add support for long press detection and mobile copying (I'll have to do research on it but should be doable)
Support ref: https://developer.mozilla.org/en-US/docs/Web/Events/contextmenu