### PR TITLE
Removes broken feature and handles right click

### DIFF
--- a/direct.js
+++ b/direct.js
@@ -82,19 +82,7 @@
     
     let fbclick = function(event) { 
         event.stopPropagation();
-        uri = cleanup();
-        var domainfilter= ['facebook.com', 'facebookwww.onion'];
-        var ovverride = false;
-        domainfilter.forEach(function(url) {
-            if (uri.indexOf(url) === -1) {
-                ovverride = true;
-            }
-        });
-        
-        if (override) {
-            window.open(uri, '_blank');
-            return false;
-        }
+        cleanup();
     }
 
     if (filter) {

--- a/direct.js
+++ b/direct.js
@@ -47,28 +47,6 @@
     win.ready = ready;
 
   ready('a', function (element) {
-    // Second level more aggressive
-    let updateElement = function() {
-      let uri = cleanup();
-      var clean = true;
-      if( uri !== '' ) {
-        // Strip all the parameters in URL
-        uri = new URL(uri);
-        var domainfilter= ['facebook.com', 'facebookwww.onion'];
-        domainfilter.forEach(function(element) {
-            if (uri.hostname.toString().indexOf(element) === -1) {
-                clean = false;
-            }
-        });
-
-        if (clean) {
-            uri = uri.protocol + '//' + uri.hostname + uri.pathname;
-            element.href = uri;
-        }
-      }
-      return uri;
-    };
-
     // First level of cleanup
     let cleanup = function() {
       let uri = element.href;
@@ -103,7 +81,7 @@
     
     let fbclick = function(event) { 
         event.stopPropagation();
-        uri = updateElement();
+        uri = cleanup();
         var domainfilter= ['facebook.com', 'facebookwww.onion'];
         var ovverride = false;
         domainfilter.forEach(function(url) {
@@ -119,9 +97,9 @@
     }
 
     if (filter) {
-      element.onmousedown = updateElement;
-      element.contextmenu = updateElement;
-      element.ontouchstart = updateElement;
+      element.onmousedown = cleanup;
+      element.contextmenu = cleanup;
+      element.ontouchstart = cleanup;
       element.onclick = fbclick;
     } else {
       element.onmousedown = cleanup;

--- a/direct.js
+++ b/direct.js
@@ -68,6 +68,7 @@
         }
 
         let eventBlocker = function(evt) {
+            cleanup();
             evt.stopImmediatePropagation();
         }
 

--- a/direct.js
+++ b/direct.js
@@ -72,28 +72,15 @@
     var url = element.href.toString();
     if (url === '') return;
 
-    var whitelist = ['#', '/profile.php', '/photo/download', '/groups', '/ad_campaign', '/pages', '&notif_t', '/photos/', '/photo/'];
-    var filter = true;
-    whitelist.forEach(function(element) {
-      if (url.indexOf(element) !== -1) {
-        filter = false;
-      }
-    });
-    
-    let fbclick = function(event) { 
-        event.stopPropagation();
-        cleanup();
-    }
+    var domainfilter= ['facebook.com', 'facebookwww.onion'];
+    var domain = (new URL(url)).hostname.toString()
+                    .split('.').slice(-2).join('.');
+    var trackerLinkRegex = /^https?:\/\/lm?.(facebook\.com|facebookwww\.onion)\/l.php\?u=([^&#$]+)/i;
 
-    if (filter) {
-      element.onmousedown = cleanup;
-      element.contextmenu = cleanup;
-      element.ontouchstart = cleanup;
-      element.onclick = fbclick;
-    } else {
-      element.onmousedown = cleanup;
-      element.contextmenu = cleanup;
-      element.ontouchstart = cleanup;
+    if( !domainfilter.includes(domain) || trackerLinkRegex.test(url) ) { //external links
+        element.onmousedown = cleanup;
+        element.contextmenu = cleanup;
+        element.ontouchstart = cleanup;
     }
   });
 

--- a/direct.js
+++ b/direct.js
@@ -49,8 +49,8 @@
   ready('a', function (element) {
     // First level of cleanup
     let cleanup = function() {
-      let uri = element.href;
-      if( uri !== '' ) {
+        let uri = element.href;
+
         if (/^https?:\/\/lm?.facebook.com/i.test(uri)) {
             uri = uri.match(/u=([^&#$]+)/i)[1];
         }
@@ -67,10 +67,11 @@
 
         element.href = uri;
         return uri;
-      }
     }
 
     var url = element.href.toString();
+    if (url === '') return;
+
     var whitelist = ['#', '/profile.php', '/photo/download', '/groups', '/ad_campaign', '/pages', '&notif_t', '/photos/', '/photo/'];
     var filter = true;
     whitelist.forEach(function(element) {

--- a/direct.js
+++ b/direct.js
@@ -66,7 +66,10 @@
         }
 
         element.href = uri;
-        return uri;
+    }
+
+    let eventBlocker = function(evt) {
+        evt.stopImmediatePropagation();
     }
 
     var url = element.href.toString();
@@ -78,9 +81,12 @@
     var trackerLinkRegex = /^https?:\/\/lm?.(facebook\.com|facebookwww\.onion)\/l.php\?u=([^&#$]+)/i;
 
     if( !domainfilter.includes(domain) || trackerLinkRegex.test(url) ) { //external links
-        element.onmousedown = cleanup;
-        element.contextmenu = cleanup;
-        element.ontouchstart = cleanup;
+        element.addEventListener('click', eventBlocker);
+        element.addEventListener('contextmenu', eventBlocker);
+        element.addEventListener('touchstart', eventBlocker);
+        element.addEventListener('mousedown', eventBlocker);
+        element.addEventListener('mouseup', eventBlocker);
+        cleanup();
     }
   });
 


### PR DESCRIPTION
I believe usual left click did not lead to l.facebook.com tracker anymore (Facebook probably uses another way to track clicks).

This refactoring handles right click preventing all Facebook events to be triggered by mouse-clicking on external links (outside facebook.com and facebookwww.onion domains).

You’ll find details in commit messages.

Please feel free to cherry pick any commit, they are all in [CC0](https://creativecommons.org/publicdomain/zero/1.0/deed) license.