### PR TITLE
Fix Facebook Onion V2 address in direct.js

### DIFF
--- a/direct.js
+++ b/direct.js
@@ -85,10 +85,10 @@
         var url = element.href.toString();
         if (url === '') return;
 
-        var domainfilter= ['facebook.com', 'facebookwww.onion', 'facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion'];
+        var domainfilter= ['facebook.com', 'facebookcorewwwi.onion', 'facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion'];
         var domain = (new URL(url)).hostname.toString()
                         .split('.').slice(-2).join('.');
-        var trackerLinkRegex = /^https?:\/\/lm?.(facebook\.com|facebookwww\.onion|facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd\.onion)\/l.php\?u=([^&#$]+)/i;
+        var trackerLinkRegex = /^https?:\/\/lm?.(facebook\.com|facebookcorewwwi\.onion|facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd\.onion)\/l.php\?u=([^&#$]+)/i;
 
         if( !domainfilter.includes(domain) || trackerLinkRegex.test(url) ) { //external links
             element.addEventListener('click', eventBlocker);


### PR DESCRIPTION
The domain in manifest.json is correct but was wrong in direct.js, was
added originally by 8aa8996bea9fcb7e48898230a5af059b1bd084da.

Reference:
- https://wikiless.org/wiki/Facebook_onion_address