### PR TITLE
Fix Facebook Onion address matches in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.facebook.com/*", "*://facebookcorewwwi.onion/*", "*://facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/*"],
+      "matches": ["*://*.facebook.com/*", "*://*.facebookcorewwwi.onion/*", "*://*.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/*"],
       "js": ["direct.js"]
     }
   ]


### PR DESCRIPTION
They actually don't use the apex domain but use the `www.` prefixed domain just like `www.facebook.com`, as you can see:

```sh
$ curl --no-location -I https://facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion --socks5-hostname 127.0.0.1:9050
HTTP/2 301 
location: https://www.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/
strict-transport-security: max-age=15552000; includeSubDomains
content-type: text/html; charset="utf-8"
.
.
.
```